### PR TITLE
Added gte to node engine version

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "request-promise": "^4.2.1"
   },
   "engines": {
-    "node": "0.10.20"
+    "node": ">=0.10.20"
   }
 }


### PR DESCRIPTION
Yarn have a strict engine validation since v1.0.0
`"node": "0.10.20"` makes `yarn add salesmachine-node` fails if node version used is greather than 0.10.2